### PR TITLE
Fix argument of BitsParser.load_qmgr_jobs in process_file method

### DIFF
--- a/BitsParser.py
+++ b/BitsParser.py
@@ -363,7 +363,7 @@ class BitsParser:
             # Parse as a qmgr database (support old and Win10 formats)
             jobs = []
             if BitsParser.is_qmgr_database(file_data):
-                jobs = self.load_qmgr_jobs(file_data)
+                jobs = self.load_qmgr_jobs(file_path)
             elif BitsParser.is_qmgr10_database(file_data):
                 jobs = self.load_qmgr10_jobs(file_data)
 


### PR DESCRIPTION
Instead of passing bytes-like object (`file_data`) to bits_parser's (https://github.com/ANSSI-FR/bits_parser) method
`bits/bits.py->load_file(cls, fp)` which expects str-like object (simple file path) , simply pass `file_path` argument of `BitsParser.process_file` method.

Here it is shown how passed argument is treated in `bits_parser/bits/bits.py->load_file`
https://github.com/ANSSI-FR/bits_parser/blob/717337cd7a0f97561b77543fb0cebb4e7ce7c0b7/bits/bits.py#L47
```python
def load_file(cls, fp):
        ...
        logger.info('Processing BITS queue %s' % fp)

        rv = cls()

        path = Path(fp).resolve()
        ...
```

Without this change BitsParser fails to parse old format qmgr state files (with .dat extension) with next exception:

```python
Processing file <path>\qmgr0.dat
Exception occurred processing file <path>\qmgr0.dat: Traceback (most recent call last):
  File "BitsParser.py", line 366, in process_file
    jobs = self.load_qmgr_jobs(file_data)
  File "BitsParser.py", line 101, in load_qmgr_jobs
    analyzer = bits.Bits.load_file(file_data)
  File "<python_path>\bits.py", line 46, in load_file
    path = Path(fp).resolve()
  File "<python_path>\lib\pathlib.py", line 1027, in __new__
    self = cls._from_parts(args, init=False)
  File "<python_path>\lib\pathlib.py", line 674, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "<python_path>\lib\pathlib.py", line 666, in _parse_args
    % type(a))
TypeError: argument should be a str object or an os.PathLike object returning str, not <class 'bytes'>
```